### PR TITLE
Fix max_features metric initialization and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -99,6 +99,7 @@ if uploaded_file or example_data:
         st.write("Model training ...")
         time.sleep(sleep_time)
 
+        parameter_max_features_metric = parameter_max_features
         if parameter_max_features == 'all':
             parameter_max_features = None
             parameter_max_features_metric = X.shape[1]

--- a/tests/test_max_features.py
+++ b/tests/test_max_features.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+
+def compute_metric(parameter_max_features, X):
+    parameter_max_features_metric = parameter_max_features
+    if parameter_max_features == 'all':
+        parameter_max_features = None
+        parameter_max_features_metric = X.shape[1]
+    return parameter_max_features_metric
+
+
+def test_metric_all():
+    X = pd.DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
+    assert compute_metric('all', X) == X.shape[1]
+
+
+def test_metric_sqrt():
+    X = pd.DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
+    assert compute_metric('sqrt', X) == 'sqrt'


### PR DESCRIPTION
## Summary
- initialize `parameter_max_features_metric` before the `'all'` check
- keep metric consistent when `'all'` is selected
- add basic unit tests
- ignore Python caches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b8515d248330951538e4c8527334