### PR TITLE
Add pytest test for convert_df

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ This is filler text, please replace this with a explanatory text about further r
 - Resource 1
 - Resource 2
 - Resource 3
+
+## Testing
+
+Install dependencies from `requirements.txt` and run:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit==1.29.0
 pandas>=1.3.0
 scikit-learn
 altair>=4.0
+pytest

--- a/tests/test_convert_df.py
+++ b/tests/test_convert_df.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import importlib
+import pandas as pd
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def test_convert_df_returns_bytes_with_header():
+    module = importlib.import_module('streamlit_app')
+    df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+    result = module.convert_df(df)
+
+    assert isinstance(result, bytes)
+    assert result.startswith(b'col1,col2')


### PR DESCRIPTION
## Summary
- add unit test for convert_df
- document test command in README
- include pytest in dependencies

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841b85e6088833099e76b3c2425802e